### PR TITLE
Implement basic layout and CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,119 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Projekt: deineTrainerin.at – Eigenentwicklung (Laravel)
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+## Zielsetzung
+Kompletter Relaunch der Website https://deinetrainerin.at/v2/ auf Basis von Laravel 11, als Self-Hosted Lösung für eigenen Server, 100 % kostenfreie Libraries, deutsch/englisch, sehr einfach zu bedienen, mit eigenem CMS und Terminbuchung.
 
-## About Laravel
+## Features
+- **Komplett editierbare Inhalte (Texte, Bilder) per Backend/CMS**
+- **Online-Terminbuchungssystem** (eigene Entwicklung, kein externer Dienst)
+- **Mehrsprachigkeit** (Deutsch & Englisch, für alle Seiten und Funktionen)
+- **Kontaktformular** mit DSGVO-Checkbox
+- **Social Media-Links, Kartenintegration (DSGVO-konform), Impressum/Datenschutz**
+- **SEO-Optimierung** (Meta-Tags, Sitemap, Performance, strukturierte Daten)
+- **Responsives Design nach Styleguide der Originalseite**
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+## Tech Stack
+- **Backend:** Laravel 11 (PHP 8.2+)
+- **Datenbank:** MariaDB/MySQL
+- **Frontend:** Tailwind CSS (oder Bootstrap 5), eigene Komponenten
+- **Kalender:** FullCalendar.js (MIT), Integration in eigene Buchungskomponente
+- **Mail:** PHPMailer (oder Laravel Mail), SMTP
+- **Mehrsprachigkeit:** Laravel Localization (lang files), Content in DB pro Sprache
+- **Bilder:** lokal oder S3-kompatibles Storage
+- **Sonstiges:** DSGVO-konformer Cookie Consent (z. B. Klaro.js), lokale Google Fonts
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+## Systemanforderungen
+- PHP 8.2+
+- Composer
+- MySQL/MariaDB
+- Node.js & npm (für Assets)
+- Linux Server (Apache/Nginx)
+- HTTPS/SSL empfohlen (Let’s Encrypt)
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+## Setup (Development)
+1. Repository klonen  
+   `git clone <repo-url> && cd deinetrainerin`
+   Das Repository enthält bereits die grundlegende Laravel-Struktur.
+2. .env Datei konfigurieren (`cp .env.example .env` und anpassen)
+3. PHP-Abhängigkeiten installieren
+   `composer install`
+4. Node-Abhängigkeiten installieren
+   `npm install`
+   
+   Für die Entwicklung kann `npm run dev` verwendet werden,
+   um Tailwind im Watch-Modus zu starten. Für einen einmaligen
+   Build der Assets genügt `npm run build`.
+   (Internetverbindung erforderlich.)
+5. App Key generieren
+   `php artisan key:generate`
+6. Datenbank anlegen und migraten
+   `php artisan migrate`
+7. Seed-User/Admin anlegen
+   `php artisan db:seed`
+8. (Optional) Storage-Link setzen
+   `php artisan storage:link`
+9. Lokalen Server starten
+   `php artisan serve`
+10. In einem zweiten Terminal den Asset-Watcher starten
+    `npm run dev`
 
-## Learning Laravel
+    Anschließend ist die Seite unter http://localhost:8000 erreichbar.
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+## Testing
+Nach dem Einrichten aller Abhängigkeiten kann die Testumgebung mit PHPUnit ausgeführt werden.
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+1. Beispieltest ausführen:
+   `composer run test`
+   Dieser Befehl startet PHPUnit und führt alle Tests im Verzeichnis `tests` aus.
+2. Weitere Tests können im Ordner `tests` abgelegt werden. Die Konfiguration befindet sich in `phpunit.xml`.
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+## Datenmodelle (Task 2)
+Die grundlegenden Tabellen werden per Migration angelegt:
+- **users** – Name, E-Mail, Passwort-Hash und ein `is_admin` Flag.
+- **pages** – Seitenslug, Titel und Inhalt jeweils auf Deutsch und Englisch sowie optionale Meta-Tags.
+- **appointments** – Termine mit Start-/Endzeit, Kundendaten und Status.
+- **translations** – Schluessel/Locale und Text für dynamische Übersetzungen.
 
-## Laravel Sponsors
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+## Deployment (Produktiv)
+- Production-ENV und DB einrichten
+- Assets kompilieren: `npm run build`
+- Caching aktivieren: `php artisan config:cache route:cache view:cache`
+- HTTPS aktivieren
+- Cronjob für Termin-Erinnerungen etc. (optional)
 
-### Premium Partners
+## Wichtige Pfade & Strukturen
+- `app/Models` – Datenmodelle (Pages, Appointment, Translation, User)
+- `app/Http/Controllers` – Controller für Frontend, API, Backend (CMS)
+- `resources/views` – Blade Templates (Layout, Pages, Admin, Booking)
+- `resources/lang/de` und `resources/lang/en` – Sprachdateien
+- `routes/web.php` – Seitenrouten
+- `public/img` – Bilder
+- `storage/app/public` – Uploads
 
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
+## TODO / Offene Tasks
+Siehe Agents.md für komplette Aufgabenaufteilung.
 
-## Contributing
+---
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+## FAQ
+- **Kann ich Inhalte ohne Code ändern?**  
+  Ja, alle Haupttexte und Bilder sind über das CMS/Backend pflegbar, inklusive Listen, Überschriften und Meta-Tags.
+- **Wie kann ich Termine verwalten?**  
+  Termine werden im Backend (nur für Admin) verwaltet, Nutzer sehen nur freie Slots.
+- **Wie werden Übersetzungen gepflegt?**  
+  Entweder in Sprachdateien (`resources/lang`) für statische UI-Elemente oder als Textfelder pro Sprache im Backend für editierbare Inhalte.
 
-## Code of Conduct
+---
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+## Autoren & Support
+- Hauptentwicklung: [Dein Name]
+- Kontakt: [Deine Mail]
+- Dokumentation: requirements.md, Agents.md, Handbuch.pdf
 
-## Security Vulnerabilities
+---
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
 
-## License
+## Aktueller Stand (Phase 2)
+Die Basis-Struktur des CMS wurde implementiert. Tailwind CSS sorgt für das responsive Layout und ein einfaches Admin-Interface ermöglicht das Bearbeiten von Seiteninhalten auf Deutsch und Englisch. Zum Einsatz kommt CKEditor als WYSIWYG-Komponente. Ein Standard-Admin-User wird über den Seeder angelegt (`admin@example.com` / `password`).
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Page;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class PageController extends Controller
+{
+    public function index(): View
+    {
+        return view('admin.pages.index', ['pages' => Page::all()]);
+    }
+
+    public function create(): View
+    {
+        return view('admin.pages.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'slug' => 'required|unique:pages,slug',
+            'title_de' => 'nullable',
+            'title_en' => 'nullable',
+            'content_de' => 'nullable',
+            'content_en' => 'nullable',
+        ]);
+        Page::create($data);
+        return redirect()->route('pages.index');
+    }
+
+    public function edit(Page $page): View
+    {
+        return view('admin.pages.edit', compact('page'));
+    }
+
+    public function update(Request $request, Page $page): RedirectResponse
+    {
+        $data = $request->validate([
+            'slug' => 'required|unique:pages,slug,' . $page->id,
+            'title_de' => 'nullable',
+            'title_en' => 'nullable',
+            'content_de' => 'nullable',
+            'content_en' => 'nullable',
+        ]);
+        $page->update($data);
+        return redirect()->route('pages.index');
+    }
+
+    public function destroy(Page $page): RedirectResponse
+    {
+        $page->delete();
+        return redirect()->route('pages.index');
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class LoginController extends Controller
+{
+    public function showLoginForm(): View
+    {
+        return view('admin.login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+            return redirect()->intended('/admin/pages');
+        }
+
+        return back()->withErrors([
+            'email' => 'Die Anmeldedaten sind ungültig.',
+        ])->onlyInput('email');
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return redirect('/');
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\View\View;
+
+class HomeController extends Controller
+{
+    public function index(): View
+    {
+        return view('home');
+    }
+}

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Appointment extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'start_at',
+        'end_at',
+        'name',
+        'email',
+        'phone',
+        'notes',
+        'status',
+    ];
+
+    protected $dates = [
+        'start_at',
+        'end_at',
+    ];
+}

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Page extends Model
+{
+    protected $fillable = [
+        'slug',
+        'title_de',
+        'title_en',
+        'content_de',
+        'content_en',
+        'meta_title_de',
+        'meta_title_en',
+        'meta_description_de',
+        'meta_description_en',
+    ];
+}

--- a/app/Models/Translation.php
+++ b/app/Models/Translation.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Translation extends Model
+{
+    protected $fillable = [
+        'key',
+        'locale',
+        'value',
+    ];
+}

--- a/database/migrations/2025_07_06_000100_create_pages_table.php
+++ b/database/migrations/2025_07_06_000100_create_pages_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('title_de');
+            $table->string('title_en');
+            $table->text('content_de')->nullable();
+            $table->text('content_en')->nullable();
+            $table->string('meta_title_de')->nullable();
+            $table->string('meta_title_en')->nullable();
+            $table->string('meta_description_de')->nullable();
+            $table->string('meta_description_en')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pages');
+    }
+};

--- a/database/migrations/2025_07_06_000200_create_appointments_table.php
+++ b/database/migrations/2025_07_06_000200_create_appointments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('appointments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->timestamp('start_at');
+            $table->timestamp('end_at')->nullable();
+            $table->string('name');
+            $table->string('email');
+            $table->string('phone')->nullable();
+            $table->text('notes')->nullable();
+            $table->string('status')->default('requested');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('appointments');
+    }
+};

--- a/database/migrations/2025_07_06_000300_create_translations_table.php
+++ b/database/migrations/2025_07_06_000300_create_translations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('translations', function (Blueprint $table) {
+            $table->id();
+            $table->string('key');
+            $table->string('locale');
+            $table->text('value');
+            $table->timestamps();
+            $table->unique(['key', 'locale']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('translations');
+    }
+};

--- a/database/seeders/AdminSeeder.php
+++ b/database/seeders/AdminSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class AdminSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::updateOrCreate(
+            ['email' => 'admin@example.com'],
+            [
+                'name' => 'Admin',
+                'password' => Hash::make('password'),
+                'is_admin' => true,
+            ]
+        );
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,22 +2,12 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(AdminSeeder::class);
     }
 }

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-semibold mb-4">Admin Login</h1>
+<form method="POST" action="{{ route('login') }}" class="space-y-4 max-w-md">
+    @csrf
+    <div>
+        <label class="block mb-1">E-Mail</label>
+        <input type="email" name="email" required class="border rounded w-full p-2">
+    </div>
+    <div>
+        <label class="block mb-1">Passwort</label>
+        <input type="password" name="password" required class="border rounded w-full p-2">
+    </div>
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Anmelden</button>
+</form>
+@endsection

--- a/resources/views/admin/pages/create.blade.php
+++ b/resources/views/admin/pages/create.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-semibold mb-4">Neue Seite</h1>
+<form method="POST" action="{{ route('pages.store') }}">
+    @include('admin.pages.form')
+</form>
+@endsection

--- a/resources/views/admin/pages/edit.blade.php
+++ b/resources/views/admin/pages/edit.blade.php
@@ -1,0 +1,9 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-semibold mb-4">Seite bearbeiten</h1>
+<form method="POST" action="{{ route('pages.update', $page) }}">
+    @method('PUT')
+    @include('admin.pages.form')
+</form>
+@endsection

--- a/resources/views/admin/pages/form.blade.php
+++ b/resources/views/admin/pages/form.blade.php
@@ -1,0 +1,31 @@
+@csrf
+<div class="space-y-4">
+    <div>
+        <label class="block mb-1">Slug</label>
+        <input type="text" name="slug" value="{{ old('slug', $page->slug ?? '') }}" class="border rounded w-full p-2" required>
+    </div>
+    <div>
+        <label class="block mb-1">Titel (DE)</label>
+        <input type="text" name="title_de" value="{{ old('title_de', $page->title_de ?? '') }}" class="border rounded w-full p-2">
+    </div>
+    <div>
+        <label class="block mb-1">Titel (EN)</label>
+        <input type="text" name="title_en" value="{{ old('title_en', $page->title_en ?? '') }}" class="border rounded w-full p-2">
+    </div>
+    <div>
+        <label class="block mb-1">Inhalt (DE)</label>
+        <textarea name="content_de" id="content_de" class="border rounded w-full p-2" rows="5">{{ old('content_de', $page->content_de ?? '') }}</textarea>
+    </div>
+    <div>
+        <label class="block mb-1">Inhalt (EN)</label>
+        <textarea name="content_en" id="content_en" class="border rounded w-full p-2" rows="5">{{ old('content_en', $page->content_en ?? '') }}</textarea>
+    </div>
+    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Speichern</button>
+</div>
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/@ckeditor/ckeditor5-build-classic/build/ckeditor.js"></script>
+<script>
+ClassicEditor.create(document.querySelector('#content_de'));
+ClassicEditor.create(document.querySelector('#content_en'));
+</script>
+@endpush

--- a/resources/views/admin/pages/index.blade.php
+++ b/resources/views/admin/pages/index.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-2xl font-semibold mb-4">Seiten</h1>
+<a href="{{ route('pages.create') }}" class="bg-green-600 text-white px-2 py-1 rounded">Neue Seite</a>
+<table class="min-w-full mt-4 border">
+    <thead class="bg-gray-100">
+        <tr>
+            <th class="p-2">Slug</th>
+            <th class="p-2">Titel (DE)</th>
+            <th class="p-2">Aktionen</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($pages as $page)
+        <tr>
+            <td class="border px-2">{{ $page->slug }}</td>
+            <td class="border px-2">{{ $page->title_de }}</td>
+            <td class="border px-2">
+                <a href="{{ route('pages.edit', $page) }}" class="text-blue-600">Bearbeiten</a>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="text-center py-20">
+    <h1 class="text-4xl font-bold mb-4">Willkommen bei {{ config('app.name') }}</h1>
+    <p class="text-lg">Dies ist die neue Startseite.</p>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ config('app.name') }}</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="min-h-screen flex flex-col">
+    <header class="bg-gray-800 text-white">
+        <div class="container mx-auto flex justify-between items-center p-4">
+            <a href="/" class="text-xl font-semibold">{{ config('app.name') }}</a>
+            <nav class="space-x-4">
+                <a href="/" class="hover:underline">Home</a>
+                <a href="/admin/pages" class="hover:underline">Admin</a>
+            </nav>
+        </div>
+    </header>
+    <main class="flex-1 container mx-auto p-4">
+        @yield('content')
+    </main>
+    <footer class="bg-gray-800 text-white text-center p-4">
+        &copy; {{ date('Y') }} {{ config('app.name') }}
+    </footer>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,16 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\HomeController;
+use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Admin\PageController;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::get('/', [HomeController::class, 'index']);
+
+Route::get('admin/login', [LoginController::class, 'showLoginForm'])->name('login');
+Route::post('admin/login', [LoginController::class, 'login']);
+Route::post('admin/logout', [LoginController::class, 'logout'])->name('logout');
+
+Route::middleware('auth')->prefix('admin')->group(function () {
+    Route::resource('pages', PageController::class)->except('show');
 });


### PR DESCRIPTION
## Summary
- add Tailwind-based layout with header/footer
- create home page and controller
- implement simple admin login and page management
- add migrations/models for pages, appointments and translations
- seed a default admin user
- document CMS setup in README

## Testing
- `composer run test` *(fails: composer not installed)*


------
https://chatgpt.com/codex/tasks/task_e_686aa201dd88832aa04b0cc95a1bca6a